### PR TITLE
refactor : 그룹 생성시 매핑테이블 생성, 현재 인원만 불러오는 api(#49)

### DIFF
--- a/src/main/java/swith/swithServer/domain/studyGroup/controller/GroupController.java
+++ b/src/main/java/swith/swithServer/domain/studyGroup/controller/GroupController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import swith.swithServer.domain.study.dto.MessageResponse;
 import swith.swithServer.domain.studyGroup.dto.*;
+import swith.swithServer.domain.userGroup.service.UserGroupService;
 import swith.swithServer.global.response.ApiResponse;
 import swith.swithServer.domain.studyGroup.service.GroupService;
 import swith.swithServer.domain.studyGroup.entity.StudyGroup;
@@ -21,6 +22,7 @@ import swith.swithServer.global.oauth.service.OauthService;
 public class GroupController {
     private final GroupService groupService;
     private final OauthService authService;
+    private final UserGroupService userGroupService;
 
     @PostMapping("/join")
     @Operation(summary = "스터디 그룹 가입 여부 확인")
@@ -45,6 +47,13 @@ public class GroupController {
         }
     }
 
+    @GetMapping("/{id}/getMem")
+    @Operation(summary = "현재 스터디 인원 가져오기")
+    public ApiResponse<Long> getMemberNum(@PathVariable Long id){
+        StudyGroup studyGroup = groupService.getGroupById(id);
+        Long memberNum = studyGroup.getMemberNum();
+        return new ApiResponse<>(200, memberNum);
+    }
 
     @GetMapping("/{id}")
     @Operation(summary = "공지사항 가져오기")
@@ -69,6 +78,9 @@ public class GroupController {
     @Operation(summary = "스터디 그룹 생성", description = "")
     public ApiResponse<StudyGroup> createGroup(@RequestBody GroupCreateRequest request) {
         StudyGroup createdStudyGroup = groupService.createGroup(request);
+        //로그인 유저 받아오기
+        User user= authService.getLoginUser();
+        userGroupService.createUserGroup(user, createdStudyGroup);
         return new ApiResponse<>(201, createdStudyGroup);
     }
 

--- a/src/main/java/swith/swithServer/domain/userGroup/controller/UserGroupController.java
+++ b/src/main/java/swith/swithServer/domain/userGroup/controller/UserGroupController.java
@@ -41,7 +41,6 @@ public class UserGroupController {
         User user = authService.getLoginUser();
         StudyGroup studyGroup = groupService.getGroupById(userGroupRequest.getGroupId());
         userGroupService.createUserGroup(user, studyGroup);
-        studyGroup.updateMemberNum(studyGroup.getMemberNum()+1);
         return new ApiResponse<>(201, MessageResponse.from("redirect:http://localhost:8080/api/group/"+studyGroup.getId()));
     }
 

--- a/src/main/java/swith/swithServer/domain/userGroup/service/UserGroupService.java
+++ b/src/main/java/swith/swithServer/domain/userGroup/service/UserGroupService.java
@@ -17,6 +17,7 @@ public class UserGroupService {
     @Transactional
     public UserGroup createUserGroup(User user, StudyGroup studyGroup){
         UserGroup userGroup = new UserGroup(user, studyGroup);
+        studyGroup.updateMemberNum(studyGroup.getMemberNum()+1);
         return userGroupRepository.save(userGroup);
     }
 


### PR DESCRIPTION
## PULL REQUEST

###  🧩 작업중인 브랜치

- #49 

### 💡 관련 이슈

- 관련 이슈를 입력해주세요.

### ⚡️ 작업 배경

- 작업 배경을 알려주세요.

### 🔑 주요 변경사항

- 스터디 그룹 생성시 생성자와 그룹의 매핑 테이블을 생성하게 했습니다.
- 프론트에서 스터디 현재 인원만 불러오는 api가 필요하다 해서 추가했습니다.


