### PR TITLE
refactor(#49) 매핑테이블 관련 수정, 로그인 필요한 api에 getLoginUser

### DIFF
--- a/src/main/java/swith/swithServer/domain/study/controller/StudyController.java
+++ b/src/main/java/swith/swithServer/domain/study/controller/StudyController.java
@@ -10,6 +10,8 @@ import swith.swithServer.domain.study.entity.Study;
 import swith.swithServer.domain.study.service.StudyService;
 import swith.swithServer.domain.studyGroup.entity.StudyGroup;
 import swith.swithServer.domain.studyGroup.service.GroupService;
+import swith.swithServer.domain.user.entity.User;
+import swith.swithServer.global.oauth.service.OauthService;
 import swith.swithServer.global.response.ApiResponse;
 
 import java.time.LocalDate;
@@ -21,12 +23,14 @@ import java.time.LocalDate;
 public class StudyController {
     private final StudyService studyService;
     private final GroupService groupService;
+    private final OauthService authService;
 
     @PostMapping
     @Operation(summary="스터디 일정 생성")
     public ApiResponse<StudyResponse> createStudy(
             @PathVariable Long id, @RequestBody StudyRequest studyRequest
             ){
+        User user = authService.getLoginUser();
         Study createdStudy = studyService.createStudy(studyRequest, id);
         return new ApiResponse<>(201, StudyResponse.from(createdStudy));
     }
@@ -37,6 +41,7 @@ public class StudyController {
             @PathVariable Long id,
             @PathVariable Long studyId,
             @RequestBody StudyUpdateRequest studyUpdateRequest){
+        User user = authService.getLoginUser();
         StudyGroup studyGroup = groupService.getGroupById(id);
         Study updatedStudy = studyService.updateStudy(studyId, studyUpdateRequest);
         return new ApiResponse<>(200, StudyResponse.from(updatedStudy));
@@ -45,6 +50,7 @@ public class StudyController {
     @DeleteMapping("/{studyId}")
     @Operation(summary = "스터디 일정 삭제")
     public ApiResponse<MessageResponse> deleteStudy(@PathVariable Long id, @PathVariable Long studyId){
+        User user = authService.getLoginUser();
         StudyGroup studyGroup = groupService.getGroupById(id);
         studyService.deleteStudy(studyId);
         return new ApiResponse<>(204,MessageResponse.from());
@@ -55,6 +61,7 @@ public class StudyController {
     public ApiResponse<StudyResponse> getStudyInfo(
             @PathVariable Long id,
             @PathVariable LocalDate date){
+        User user = authService.getLoginUser();
         Study study = studyService.getStudyByGroupDate(id,date);
         return new ApiResponse<>(200, StudyResponse.from(study));
 

--- a/src/main/java/swith/swithServer/domain/studyGroup/controller/GroupController.java
+++ b/src/main/java/swith/swithServer/domain/studyGroup/controller/GroupController.java
@@ -12,7 +12,6 @@ import swith.swithServer.global.response.ApiResponse;
 import swith.swithServer.domain.studyGroup.service.GroupService;
 import swith.swithServer.domain.studyGroup.entity.StudyGroup;
 import swith.swithServer.domain.user.entity.User;
-import swith.swithServer.domain.user.service.UserService;
 import swith.swithServer.global.oauth.service.OauthService;
 
 @RestController
@@ -50,6 +49,7 @@ public class GroupController {
     @GetMapping("/{id}/getMem")
     @Operation(summary = "현재 스터디 인원 가져오기")
     public ApiResponse<Long> getMemberNum(@PathVariable Long id){
+        User user = authService.getLoginUser();
         StudyGroup studyGroup = groupService.getGroupById(id);
         Long memberNum = studyGroup.getMemberNum();
         return new ApiResponse<>(200, memberNum);
@@ -59,6 +59,7 @@ public class GroupController {
     @Operation(summary = "공지사항 가져오기")
     public ApiResponse<String> getNotice(
             @PathVariable Long id) {
+        User user = authService.getLoginUser();
         StudyGroup studyGroup = groupService.getGroupById(id);
         String notice = studyGroup.getNotice();
         return new ApiResponse<>(200, notice);
@@ -69,6 +70,7 @@ public class GroupController {
     public ApiResponse<String> updateNotice(
             @PathVariable Long id,
             @RequestBody StringRequest stringRequest) {
+        User user = authService.getLoginUser();
         StudyGroup updatedNotice = groupService.updateNotice(id, stringRequest);
         return new ApiResponse<>(200, updatedNotice.getNotice());
     }
@@ -121,6 +123,7 @@ public class GroupController {
             @Parameter(description = "ID of the group to be deleted", required = true)
             @PathVariable(name = "groupId") Long groupId) {
         GroupResponse groupToDelete = groupService.getGroupDetails(groupId);
+        userGroupService.deleteUserGroup(groupId);
         groupService.deleteGroup(groupId);
         return new ApiResponse<>(200, groupToDelete); // 명시적으로 GroupResponse 반환
     }

--- a/src/main/java/swith/swithServer/domain/task/controller/TaskController.java
+++ b/src/main/java/swith/swithServer/domain/task/controller/TaskController.java
@@ -13,6 +13,8 @@ import swith.swithServer.domain.studyGroup.service.GroupService;
 import swith.swithServer.domain.task.dto.TaskResponse;
 import swith.swithServer.domain.task.entity.Task;
 import swith.swithServer.domain.task.service.TaskService;
+import swith.swithServer.domain.user.entity.User;
+import swith.swithServer.global.oauth.service.OauthService;
 import swith.swithServer.global.response.ApiResponse;
 
 import java.util.List;
@@ -25,11 +27,13 @@ public class TaskController {
     private final TaskService taskService;
     private final StudyService studyService;
     private final GroupService groupService;
+    private final OauthService authService;
 
 
     @PostMapping("/create")
     @Operation(summary = "과제 생성")
     public ApiResponse<TaskResponse> createTask(@PathVariable Long id, @PathVariable Long studyId, @RequestBody StringRequest stringRequest){
+        User user = authService.getLoginUser();
         StudyGroup studyGroup = groupService.getGroupById(id);
         Task createdTask = taskService.createTask(studyId, stringRequest);
         return new ApiResponse<>(201, TaskResponse.from(createdTask));
@@ -38,6 +42,7 @@ public class TaskController {
     @GetMapping("/get")
     @Operation(summary = "과제 가져오기")
     public ApiResponse<List<TaskResponse>> getTask(@PathVariable Long id, @PathVariable Long studyId){
+        User user = authService.getLoginUser();
         StudyGroup studyGroup = groupService.getGroupById(id);
         Study study = studyService.getStudyById(studyId);
         List<Task> task = taskService.getTaskByStudy(study);
@@ -47,6 +52,7 @@ public class TaskController {
     @DeleteMapping("/{taskId}")
     @Operation(summary = "과제 삭제")
     public ApiResponse<MessageResponse> deleteTask(@PathVariable Long id, @PathVariable Long studyId, @PathVariable Long taskId){
+        User user = authService.getLoginUser();
         StudyGroup studyGroup = groupService.getGroupById(id);
         Study study = studyService.getStudyById(studyId);
         taskService.deleteTask(taskId);

--- a/src/main/java/swith/swithServer/domain/userGroup/repository/UserGroupRepository.java
+++ b/src/main/java/swith/swithServer/domain/userGroup/repository/UserGroupRepository.java
@@ -5,11 +5,16 @@ import swith.swithServer.domain.studyGroup.entity.StudyGroup;
 import swith.swithServer.domain.userGroup.entity.UserGroup;
 import swith.swithServer.domain.user.entity.User;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
     boolean existsByUserAndStudyGroup(User user, StudyGroup studyGroup);
 
     // 그룹에 속한 모든 UserGroup 조회
     List<UserGroup> findAllByStudyGroup(StudyGroup studyGroup);
+
+    //user랑 group으로 usergroup조회
+    Optional<UserGroup> findByStudyGroupAndUser(StudyGroup studyGroup, User user);
 }

--- a/src/main/java/swith/swithServer/domain/userGroup/service/UserGroupService.java
+++ b/src/main/java/swith/swithServer/domain/userGroup/service/UserGroupService.java
@@ -4,21 +4,40 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import swith.swithServer.domain.studyGroup.entity.StudyGroup;
+import swith.swithServer.domain.studyGroup.repository.GroupRepository;
 import swith.swithServer.domain.userGroup.entity.UserGroup;
 import swith.swithServer.domain.user.entity.User;
 import swith.swithServer.domain.userGroup.repository.UserGroupRepository;
+import swith.swithServer.global.error.ErrorCode;
+import swith.swithServer.global.error.exception.BusinessException;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class UserGroupService {
     private final UserGroupRepository userGroupRepository;
+    private final GroupRepository groupRepository;
+
 
     //매핑테이블 생성
     @Transactional
     public UserGroup createUserGroup(User user, StudyGroup studyGroup){
+        if(userGroupRepository.findByStudyGroupAndUser(studyGroup, user).isPresent()){
+            throw new BusinessException(ErrorCode.ALREADY_JOIN);
+        }
         UserGroup userGroup = new UserGroup(user, studyGroup);
         studyGroup.updateMemberNum(studyGroup.getMemberNum()+1);
         return userGroupRepository.save(userGroup);
+    }
+
+    //매핑테이블 삭제
+    @Transactional
+    public void deleteUserGroup(Long id){
+        StudyGroup studyGroup = groupRepository.findById(id)
+                .orElseThrow(()->new BusinessException(ErrorCode.GROUP_DOESNT_EXIST));
+        List<UserGroup> userGroups=userGroupRepository.findAllByStudyGroup(studyGroup);
+        userGroupRepository.deleteAllInBatch(userGroups);
     }
 
 }

--- a/src/main/java/swith/swithServer/global/error/ErrorCode.java
+++ b/src/main/java/swith/swithServer/global/error/ErrorCode.java
@@ -42,6 +42,8 @@ public enum ErrorCode {
 
     GROUP_LOGIN_ERROR(404, "아이디와 비밀번호가 일치하지 않습니다."),
 
+    ALREADY_JOIN(404, "이미 가입한 그룹입니다."),
+
     //STUDY
     STUDY_DOESNT_EXIST(404,"존재하지 않는 스터디 일정입니다."),
 


### PR DESCRIPTION

## PULL REQUEST

###  🧩 작업중인 브랜치

- #49 

### 💡 관련 이슈

- 관련 이슈를 입력해주세요.

### ⚡️ 작업 배경

- 작업 배경을 알려주세요.

### 🔑 주요 변경사항

- 매핑테이블 삭제 함수 구현
- 스터디 그룹 삭제시, 해당 그룹과 매핑되있는 매핑테이블 전체 삭제
- 중복 매핑테이블 생성 방지
- 로그인 후 이용하는 api에 getLoginUser 추가


