### PR TITLE
refactor : 과제 불러오기에 과제 상태 추가, 삭제시 참조키 관계 먼저 삭제 구현

### DIFF
--- a/src/main/java/swith/swithServer/domain/study/service/StudyService.java
+++ b/src/main/java/swith/swithServer/domain/study/service/StudyService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import swith.swithServer.domain.comment.entity.Comment;
 import swith.swithServer.domain.comment.repository.CommentRepository;
+import swith.swithServer.domain.comment.service.CommentService;
 import swith.swithServer.domain.study.dto.StudyRequest;
 import swith.swithServer.domain.study.dto.StudyUpdateRequest;
 import swith.swithServer.domain.studyGroup.entity.StudyGroup;
@@ -14,7 +15,7 @@ import swith.swithServer.domain.study.entity.Study;
 import swith.swithServer.domain.study.repository.StudyRepository;
 import swith.swithServer.domain.task.entity.Task;
 import swith.swithServer.domain.task.repository.TaskRepository;
-import swith.swithServer.domain.usertask.repository.UserTaskRepository;
+import swith.swithServer.domain.task.service.TaskService;
 import swith.swithServer.global.error.ErrorCode;
 import swith.swithServer.global.error.exception.BusinessException;
 
@@ -28,6 +29,8 @@ public class StudyService {
     private final GroupRepository groupRepository;
     private final CommentRepository commentRepository;
     private final TaskRepository taskRepository;
+    private final TaskService taskService;
+    private final CommentService commentService;
 
     //id로 찾기
     public Study getStudyById(Long id){
@@ -74,9 +77,13 @@ public class StudyService {
         //일정 삭제시 출석 상태, 코멘트, 과제 테이블 삭제
 //출석 상태는 아직 없어서 추후에 추가
         List<Comment> comments = commentRepository.findByStudyIdOrderByIdAsc(id);
-        commentRepository.deleteAll(comments);
+        for(Comment comment : comments){
+            commentService.deleteComment(comment.getId());
+        }
         List<Task> tasks = taskRepository.findByStudy(study);
-        taskRepository.deleteAll(tasks);
+        for(Task task : tasks){
+            taskService.deleteTask(task.getId());
+        }
         studyRepository.delete(study);
     }
 

--- a/src/main/java/swith/swithServer/domain/studyGroup/service/GroupService.java
+++ b/src/main/java/swith/swithServer/domain/studyGroup/service/GroupService.java
@@ -3,6 +3,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import swith.swithServer.domain.study.service.StudyService;
 import swith.swithServer.domain.studyGroup.dto.*;
 import swith.swithServer.domain.studyGroup.entity.StudyGroup;
 import swith.swithServer.domain.studyGroup.repository.GroupRepository;
@@ -26,6 +27,7 @@ public class GroupService {
     private final UserGroupRepository userGroupRepository;
     private final OauthService authService;
     private final StudyRepository studyRepository;
+    private final StudyService studyService;
 
 
     //id로 찾기
@@ -108,8 +110,9 @@ public class GroupService {
         userGroupRepository.deleteAll(userGroups);
 
         List<Study> studies = studyRepository.findAllByStudyGroup(studyGroup);
-        studyRepository.deleteAll(studies);
-
+        for(Study study : studies){
+            studyService.deleteStudy(study.getId());
+        }
         GroupResponse groupResponse = GroupResponse.from(studyGroup);
 
         groupRepository.deleteById(groupId);

--- a/src/main/java/swith/swithServer/domain/task/controller/TaskController.java
+++ b/src/main/java/swith/swithServer/domain/task/controller/TaskController.java
@@ -14,6 +14,8 @@ import swith.swithServer.domain.task.dto.TaskResponse;
 import swith.swithServer.domain.task.entity.Task;
 import swith.swithServer.domain.task.service.TaskService;
 import swith.swithServer.domain.user.entity.User;
+import swith.swithServer.domain.usertask.entity.UserTask;
+import swith.swithServer.domain.usertask.service.UserTaskService;
 import swith.swithServer.global.oauth.service.OauthService;
 import swith.swithServer.global.response.ApiResponse;
 
@@ -28,6 +30,7 @@ public class TaskController {
     private final StudyService studyService;
     private final GroupService groupService;
     private final OauthService authService;
+    private final UserTaskService userTaskService;
 
 
     @PostMapping("/create")
@@ -35,8 +38,9 @@ public class TaskController {
     public ApiResponse<TaskResponse> createTask(@PathVariable Long id, @PathVariable Long studyId, @RequestBody StringRequest stringRequest){
         User user = authService.getLoginUser();
         StudyGroup studyGroup = groupService.getGroupById(id);
-        Task createdTask = taskService.createTask(studyId, stringRequest);
-        return new ApiResponse<>(201, TaskResponse.from(createdTask, user));
+        Task createdTask = taskService.createTask(studyGroup, studyId, stringRequest);
+        UserTask userTask = userTaskService.getUserTaskByUserAndTask(user, createdTask);
+        return new ApiResponse<>(201, TaskResponse.from(createdTask, userTask));
     }
 
     @GetMapping("/get")
@@ -46,7 +50,8 @@ public class TaskController {
         StudyGroup studyGroup = groupService.getGroupById(id);
         Study study = studyService.getStudyById(studyId);
         List<Task> task = taskService.getTaskByStudy(study);
-        return new ApiResponse<>(200, TaskResponse.from(task, user));
+        List<UserTask> userTasks = userTaskService.getUserTaskByUserAndTaskList(user,task);
+        return new ApiResponse<>(200, TaskResponse.from(task, userTasks));
 
     }
     @DeleteMapping("/{taskId}")

--- a/src/main/java/swith/swithServer/domain/task/dto/TaskResponse.java
+++ b/src/main/java/swith/swithServer/domain/task/dto/TaskResponse.java
@@ -3,18 +3,29 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import swith.swithServer.domain.task.entity.Task;
 import swith.swithServer.domain.user.entity.User;
 import swith.swithServer.domain.usertask.entity.TaskStatus;
+import swith.swithServer.domain.usertask.entity.UserTask;
+import swith.swithServer.domain.usertask.repository.UserTaskRepository;
+import swith.swithServer.domain.usertask.service.UserTaskService;
+import swith.swithServer.global.error.ErrorCode;
+import swith.swithServer.global.error.exception.BusinessException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class TaskResponse {
+
+    private static UserTaskService userTaskService;
+
     private Long id;
 
     @NotNull
@@ -24,20 +35,26 @@ public class TaskResponse {
     @Column(length = 50)
     private String content;
 
-    public static TaskResponse from(Task task, User user){
+    public static TaskResponse from(Task task, UserTask userTask){
+
         return TaskResponse.builder()
                 .id(task.getId())
+                .taskStatus(userTask.getTaskStatus())
                 .content(task.getContent())
                 .build();
     }
-    public static List<TaskResponse> from(List<Task> task, User user){
+
+    public static List<TaskResponse> from(List<Task> task, List<UserTask> userTasks){
         List<TaskResponse> taskResponseList = new ArrayList<>();
+        int i=0;
         for(Task tasks : task){
             TaskResponse taskResponse = TaskResponse.builder()
                     .id(tasks.getId())
+                    .taskStatus(userTasks.get(i).getTaskStatus())
                     .content(tasks.getContent())
                     .build();
             taskResponseList.add(taskResponse);
+            i++;
         }
         return taskResponseList;
     }

--- a/src/main/java/swith/swithServer/domain/usertask/repository/UserTaskRepository.java
+++ b/src/main/java/swith/swithServer/domain/usertask/repository/UserTaskRepository.java
@@ -1,6 +1,7 @@
 package swith.swithServer.domain.usertask.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import swith.swithServer.domain.user.entity.User;
 import swith.swithServer.domain.usertask.entity.UserTask;
 import swith.swithServer.domain.task.entity.Task;
 
@@ -10,4 +11,5 @@ import java.util.Optional;
 public interface UserTaskRepository extends JpaRepository<UserTask, Long> {
     Optional<UserTask> findByUserIdAndId(Long userId, Long taskId);
     List<UserTask> findAllByTask(Task task);
+    Optional<UserTask> findByUserAndTask(User user, Task task);
 }

--- a/src/main/java/swith/swithServer/domain/usertask/service/UserTaskService.java
+++ b/src/main/java/swith/swithServer/domain/usertask/service/UserTaskService.java
@@ -19,6 +19,7 @@ import swith.swithServer.domain.task.entity.Task;
 import swith.swithServer.domain.studyGroup.entity.StudyGroup;
 import swith.swithServer.domain.studyGroup.repository.GroupRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -30,6 +31,27 @@ public class UserTaskService {
     private final UserRepository userRepository;
     private final GroupRepository studyGroupRepository;
     private final TaskRepository taskRepository;
+
+
+    //user랑 task로 usertask 찾기
+    public UserTask getUserTaskByUserAndTask(User user, Task task) {
+        UserTask userTask = userTaskRepository.findByUserAndTask(user,task)
+                .orElseThrow(()-> new BusinessException(ErrorCode.USER_TASK_NOT_FOUND));
+        return userTask;
+    }
+
+    //user랑 tasklislt로 usertask 찾기
+    public List<UserTask> getUserTaskByUserAndTaskList(User user, List<Task> tasks){
+        List<UserTask> userTaskList = new ArrayList<>();
+        for( Task task : tasks){
+            UserTask userTask = userTaskRepository.findByUserAndTask(user, task)
+                    .orElseThrow(()->new BusinessException(ErrorCode.USER_TASK_NOT_FOUND));
+            userTaskList.add(userTask);
+        }
+        return userTaskList;
+    }
+
+
 
     // 과제 상태 Update
     @Transactional


### PR DESCRIPTION
## PULL REQUEST

###  🧩 작업중인 브랜치

- #49 

### 💡 관련 이슈

- 관련 이슈를 입력해주세요.

### ⚡️ 작업 배경

- 작업 배경을 알려주세요.

### 🔑 주요 변경사항

- 그룹 삭제시 -> 해당 스터디 일정 삭제->일정의 과제 삭제->usertask매핑테이블 삭제 구현

- 과제를 불러올 때 불러오는 각 유저에 맞는 과제 상태 추가

